### PR TITLE
Handle swiftc -dump-ast output format

### DIFF
--- a/SwiftExP.xcodeproj/project.pbxproj
+++ b/SwiftExP.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		29466BC11BAC1B6B007D2611 /* test.reserialized.swift-ast in Resources */ = {isa = PBXBuildFile; fileRef = 29466BC01BAC1B6B007D2611 /* test.reserialized.swift-ast */; settings = {ASSET_TAGS = (); }; };
 		29A0EAC11B327A01009DE2DF /* ParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A0EAC01B327A01009DE2DF /* ParserTests.swift */; };
 		29A0EACD1B32C10A009DE2DF /* Parser+File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A0EACC1B32C10A009DE2DF /* Parser+File.swift */; };
 		29A0EACF1B32C2BC009DE2DF /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A0EACE1B32C2BC009DE2DF /* ModelTests.swift */; };
@@ -29,6 +30,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		29466BC01BAC1B6B007D2611 /* test.reserialized.swift-ast */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "test.reserialized.swift-ast"; sourceTree = "<group>"; };
 		29A0EAC01B327A01009DE2DF /* ParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParserTests.swift; sourceTree = "<group>"; };
 		29A0EAC21B329E3D009DE2DF /* libswiftXCTest.tbd */ = {isa = PBXFileReference; lastKnownFileType = text; name = libswiftXCTest.tbd; path = System/Library/PrivateFrameworks/Swift/libswiftXCTest.tbd; sourceTree = SDKROOT; };
 		29A0EACC1B32C10A009DE2DF /* Parser+File.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Parser+File.swift"; sourceTree = "<group>"; };
@@ -75,6 +77,7 @@
 			isa = PBXGroup;
 			children = (
 				29A0EAD11B32C62E009DE2DF /* test.swift-ast */,
+				29466BC01BAC1B6B007D2611 /* test.reserialized.swift-ast */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -220,6 +223,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				29466BC11BAC1B6B007D2611 /* test.reserialized.swift-ast in Resources */,
 				29A0EAD21B32C62E009DE2DF /* test.swift-ast in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftExP.xcodeproj/project.pbxproj
+++ b/SwiftExP.xcodeproj/project.pbxproj
@@ -8,7 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		29A0EAC11B327A01009DE2DF /* ParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A0EAC01B327A01009DE2DF /* ParserTests.swift */; };
+		29A0EACD1B32C10A009DE2DF /* Parser+File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A0EACC1B32C10A009DE2DF /* Parser+File.swift */; };
 		29A0EACF1B32C2BC009DE2DF /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A0EACE1B32C2BC009DE2DF /* ModelTests.swift */; };
+		29A0EAD21B32C62E009DE2DF /* test.swift-ast in Resources */ = {isa = PBXBuildFile; fileRef = 29A0EAD11B32C62E009DE2DF /* test.swift-ast */; };
 		29E222921B2F92210091F427 /* SwiftExP.h in Headers */ = {isa = PBXBuildFile; fileRef = 29E222911B2F92210091F427 /* SwiftExP.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29E222991B2F92210091F427 /* SwiftExP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29E2228E1B2F92210091F427 /* SwiftExP.framework */; };
 		29E222A91B2F954E0091F427 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29E222A81B2F954E0091F427 /* Model.swift */; };
@@ -29,7 +31,9 @@
 /* Begin PBXFileReference section */
 		29A0EAC01B327A01009DE2DF /* ParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParserTests.swift; sourceTree = "<group>"; };
 		29A0EAC21B329E3D009DE2DF /* libswiftXCTest.tbd */ = {isa = PBXFileReference; lastKnownFileType = text; name = libswiftXCTest.tbd; path = System/Library/PrivateFrameworks/Swift/libswiftXCTest.tbd; sourceTree = SDKROOT; };
+		29A0EACC1B32C10A009DE2DF /* Parser+File.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Parser+File.swift"; sourceTree = "<group>"; };
 		29A0EACE1B32C2BC009DE2DF /* ModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
+		29A0EAD11B32C62E009DE2DF /* test.swift-ast */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "test.swift-ast"; sourceTree = "<group>"; };
 		29E2228E1B2F92210091F427 /* SwiftExP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftExP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		29E222911B2F92210091F427 /* SwiftExP.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftExP.h; sourceTree = "<group>"; };
 		29E222931B2F92210091F427 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -67,6 +71,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		29A0EAD01B32C62E009DE2DF /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				29A0EAD11B32C62E009DE2DF /* test.swift-ast */,
+			);
+			path = Fixtures;
+			sourceTree = "<group>";
+		};
 		29E222841B2F92210091F427 = {
 			isa = PBXGroup;
 			children = (
@@ -91,6 +103,7 @@
 				29E222911B2F92210091F427 /* SwiftExP.h */,
 				29E222A81B2F954E0091F427 /* Model.swift */,
 				29FA06A11B2FBE9B00493CF0 /* Parser.swift */,
+				29A0EACC1B32C10A009DE2DF /* Parser+File.swift */,
 				29FA069F1B2FA51F00493CF0 /* Scanner.swift */,
 				29E222931B2F92210091F427 /* Info.plist */,
 			);
@@ -103,6 +116,7 @@
 				29A0EACE1B32C2BC009DE2DF /* ModelTests.swift */,
 				29A0EAC01B327A01009DE2DF /* ParserTests.swift */,
 				29E2229F1B2F92210091F427 /* Info.plist */,
+				29A0EAD01B32C62E009DE2DF /* Fixtures */,
 				29A0EAC71B329E73009DE2DF /* Frameworks */,
 			);
 			path = SwiftExPTests;
@@ -206,6 +220,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				29A0EAD21B32C62E009DE2DF /* test.swift-ast in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -216,6 +231,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				29A0EACD1B32C10A009DE2DF /* Parser+File.swift in Sources */,
 				29FA06A01B2FA51F00493CF0 /* Scanner.swift in Sources */,
 				29E222A91B2F954E0091F427 /* Model.swift in Sources */,
 				29FA06A21B2FBE9B00493CF0 /* Parser.swift in Sources */,

--- a/SwiftExP/Model.swift
+++ b/SwiftExP/Model.swift
@@ -7,10 +7,30 @@
 //
 
 public enum Expression {
-    case StringAtom(String)
-    case DecimalAtom(Double)
-    case IntegerAtom(Int)
+    case Atom(SwiftExP.Atom)
     case List([Expression])
+    
+    public init(_ string: String) {
+        self = .Atom(.String(string))
+    }
+    
+    public init(_ double: Double) {
+        self = .Atom(.Decimal(double))
+    }
+    
+    public init(_ int: Int) {
+        self = .Atom(.Integer(int))
+    }
+    
+    public init(_ array: [Expression]) {
+        self = .List(array)
+    }
+}
+
+public enum Atom {
+    case String(Swift.String)
+    case Decimal(Double)
+    case Integer(Int)
 }
 
 
@@ -19,13 +39,25 @@ extension Expression : Equatable {
 
 public func ==(lhs: Expression, rhs: Expression) -> Bool {
     switch (lhs, rhs) {
-        case (.StringAtom(let l), .StringAtom(let r)):
-            return l == r
-        case (.DecimalAtom(let l), .DecimalAtom(let r)):
-            return l == r
-        case (.IntegerAtom(let l), .IntegerAtom(let r)):
+        case (.Atom(let l), .Atom(let r)):
             return l == r
         case (.List(let l), .List(let r)):
+            return l == r
+        default:
+            return false // you're comparing apples with oranges
+    }
+}
+
+extension Atom : Equatable {
+}
+
+public func ==(lhs: Atom, rhs: Atom) -> Bool {
+    switch (lhs, rhs) {
+        case (.String(let l), .String(let r)):
+            return l == r
+        case (.Decimal(let l), .Decimal(let r)):
+            return l == r
+        case (.Integer(let l), .Integer(let r)):
             return l == r
         default:
             return false // you're comparing apples with oranges
@@ -36,16 +68,27 @@ public func ==(lhs: Expression, rhs: Expression) -> Bool {
 extension Expression : CustomStringConvertible {
     public var description: String {
         switch self {
-            case .StringAtom(let x):
-                let escaped = "\\\"".join(split(x.characters) { $0 == "\"" }.map { String($0) })
-                return "\"\(escaped)\""
-            case .DecimalAtom(let x):
-                return "\(x)"
-            case .IntegerAtom(let x):
+            case .Atom(let x):
                 return "\(x)"
             case .List(let xs):
                 let jointXs = " ".join(xs.map { String($0) })
                 return "(\(jointXs))"
+            case .Attribute(let identifier, let valueBox):
+                return "\(identifier)=\(valueBox.unbox)"
+        }
+    }
+}
+
+extension Atom : CustomStringConvertible {
+    public var description: Swift.String {
+        switch self {
+            case .String(let x):
+                let escaped = "\\\"".join(split(x.characters) { $0 == "\"" }.map { Swift.String($0) })
+                return "\"\(escaped)\""
+            case .Decimal(let x):
+                return "\(x)"
+            case .Integer(let x):
+                return "\(x)"
         }
     }
 }

--- a/SwiftExP/Model.swift
+++ b/SwiftExP/Model.swift
@@ -111,8 +111,12 @@ extension Atom : CustomStringConvertible {
     public var description: Swift.String {
         switch self {
             case .String(let x):
-                let escaped = x.characters.split("\"").map { Swift.String($0) }.joinWithSeparator("\\\"")
-                return "\"\(escaped)\""
+                if Parser.protectedChars.isDisjointWith(x.characters) {
+                    return x
+                } else {
+                    let escaped = x.characters.split("\"").map { Swift.String($0) }.joinWithSeparator("\\\"")
+                    return "\"\(escaped)\""
+                }
             case .Decimal(let x):
                 return "\(x)"
             case .Integer(let x):

--- a/SwiftExP/Model.swift
+++ b/SwiftExP/Model.swift
@@ -6,9 +6,31 @@
 //  Copyright © 2015 Marius Rackwitz. All rights reserved.
 //
 
+public class Box<T> {
+    public let unbox: T
+    
+    public init(_ content: T) {
+        self.unbox = content
+    }
+}
+
+extension Box : Equatable {
+}
+
+public func == <T>(lhs: Box<T>, rhs: Box<T>) -> Bool {
+    preconditionFailure("Inner type '\(lhs.unbox.dynamicType)' is not equatable,"
+        + "but was compared in '\(Box<T>.self)'.")
+}
+
+public func == <T where T: Equatable>(lhs: Box<T>, rhs: Box<T>) -> Bool {
+    return lhs.unbox == rhs.unbox
+}
+
+
 public enum Expression {
     case Atom(SwiftExP.Atom)
     case List([Expression])
+    case Attribute(identifier: SwiftExP.Atom, value: Box<Expression>)
     
     public init(_ string: String) {
         self = .Atom(.String(string))
@@ -24,6 +46,10 @@ public enum Expression {
     
     public init(_ array: [Expression]) {
         self = .List(array)
+    }
+    
+    public init(_ identifier: SwiftExP.Atom, _ value: Expression) {
+        self = .Attribute(identifier: identifier, value: Box(value))
     }
 }
 
@@ -43,6 +69,8 @@ public func ==(lhs: Expression, rhs: Expression) -> Bool {
             return l == r
         case (.List(let l), .List(let r)):
             return l == r
+        case (.Attribute(let lIdentifier, let lValueBox), .Attribute(let rIdentifier, let rValueBox)):
+            return lIdentifier == rIdentifier && lValueBox == rValueBox
         default:
             return false // you're comparing apples with oranges
     }

--- a/SwiftExP/Model.swift
+++ b/SwiftExP/Model.swift
@@ -99,7 +99,7 @@ extension Expression : CustomStringConvertible {
             case .Atom(let x):
                 return "\(x)"
             case .List(let xs):
-                let jointXs = " ".join(xs.map { String($0) })
+                let jointXs = " ".join(xs.map { $0.description })
                 return "(\(jointXs))"
             case .Attribute(let identifier, let valueBox):
                 return "\(identifier)=\(valueBox.unbox)"

--- a/SwiftExP/Model.swift
+++ b/SwiftExP/Model.swift
@@ -99,7 +99,7 @@ extension Expression : CustomStringConvertible {
             case .Atom(let x):
                 return "\(x)"
             case .List(let xs):
-                let jointXs = " ".join(xs.map { $0.description })
+                let jointXs = xs.map { $0.description }.joinWithSeparator(" ")
                 return "(\(jointXs))"
             case .Attribute(let identifier, let valueBox):
                 return "\(identifier)=\(valueBox.unbox)"
@@ -111,7 +111,7 @@ extension Atom : CustomStringConvertible {
     public var description: Swift.String {
         switch self {
             case .String(let x):
-                let escaped = "\\\"".join(x.characters.split("\"").map { Swift.String($0) })
+                let escaped = x.characters.split("\"").map { Swift.String($0) }.joinWithSeparator("\\\"")
                 return "\"\(escaped)\""
             case .Decimal(let x):
                 return "\(x)"

--- a/SwiftExP/Model.swift
+++ b/SwiftExP/Model.swift
@@ -120,3 +120,37 @@ extension Atom : CustomStringConvertible {
         }
     }
 }
+
+
+protocol PrettyPrintable {
+    func prettyDescription(indentation: Swift.String) -> Swift.String
+}
+
+extension Expression : PrettyPrintable {
+    public func prettyDescription(indentation: Swift.String = "") -> Swift.String {
+        switch self {
+        case .List(let xs):
+            let incIndentation = indentation + "  "
+            let listDescription = xs.reduce("") { (var accu, element) in
+                if case .List(_) = element {
+                    accu += "\n\(element.prettyDescription(incIndentation))"
+                } else {
+                    if !accu.isEmpty {
+                        accu += " "
+                    }
+                    accu += "\(element)"
+                }
+                return accu
+            }
+            return indentation + "(" + listDescription + ")"
+        default:
+            return indentation + description
+        }
+    }
+}
+
+extension Atom : PrettyPrintable {
+    public func prettyDescription(indentation: Swift.String = "") -> Swift.String {
+        return indentation + description
+    }
+}

--- a/SwiftExP/Model.swift
+++ b/SwiftExP/Model.swift
@@ -111,7 +111,7 @@ extension Atom : CustomStringConvertible {
     public var description: Swift.String {
         switch self {
             case .String(let x):
-                let escaped = "\\\"".join(split(x.characters) { $0 == "\"" }.map { Swift.String($0) })
+                let escaped = "\\\"".join(x.characters.split("\"").map { Swift.String($0) })
                 return "\"\(escaped)\""
             case .Decimal(let x):
                 return "\(x)"

--- a/SwiftExP/Parser+File.swift
+++ b/SwiftExP/Parser+File.swift
@@ -8,21 +8,13 @@
 
 import Foundation
 
-extension Optional {
-    func flatMap<U>(@noescape f: (T) throws -> U?) rethrows -> U? {
-        if case .Some(let inner) = self {
-            return try f(inner)
-        }
-        return .None
-    }
-}
 
 extension Parser {
     
     public static func parse(contentsOfFile path: String) throws -> Expression? {
         return try NSData(contentsOfFile: path).flatMap { (data) in
             try NSString(data: data, encoding: NSUTF8StringEncoding).flatMap { (nsString) in
-                let string = String(nsString)
+                let string = nsString as String
                 return try self.parse(string)
             }
         }

--- a/SwiftExP/Parser+File.swift
+++ b/SwiftExP/Parser+File.swift
@@ -1,0 +1,20 @@
+//
+//  Parser+File.swift
+//  SwiftExP
+//
+//  Created by Marius Rackwitz on 18.6.15.
+//  Copyright © 2015 Marius Rackwitz. All rights reserved.
+//
+
+import Foundation
+
+extension Parser {
+    
+    public static func parse(contentsOfFile path: String) throws -> Expression {
+        let data = NSData(contentsOfFile: path)!
+        let nsString = NSString(data: data, encoding: NSUTF8StringEncoding)!
+        let string = String(nsString)
+        return try self.parse(string)
+    }
+    
+}

--- a/SwiftExP/Parser+File.swift
+++ b/SwiftExP/Parser+File.swift
@@ -8,13 +8,24 @@
 
 import Foundation
 
+extension Optional {
+    func flatMap<U>(@noescape f: (T) throws -> U?) rethrows -> U? {
+        if case .Some(let inner) = self {
+            return try f(inner)
+        }
+        return .None
+    }
+}
+
 extension Parser {
     
-    public static func parse(contentsOfFile path: String) throws -> Expression {
-        let data = NSData(contentsOfFile: path)!
-        let nsString = NSString(data: data, encoding: NSUTF8StringEncoding)!
-        let string = String(nsString)
-        return try self.parse(string)
+    public static func parse(contentsOfFile path: String) throws -> Expression? {
+        return try NSData(contentsOfFile: path).flatMap { (data) in
+            try NSString(data: data, encoding: NSUTF8StringEncoding).flatMap { (nsString) in
+                let string = String(nsString)
+                return try self.parse(string)
+            }
+        }
     }
     
 }

--- a/SwiftExP/Parser.swift
+++ b/SwiftExP/Parser.swift
@@ -185,15 +185,17 @@ public struct Parser {
     }
     
     static let whitespaceChars: Set<Character> = Set(" \r\t\n".characters)
-    static let quotationChars: Set<Character> = Set("\"".characters)
-    static let protectedChars: Set<Character> = Parser.whitespaceChars.union(Set("\"()".characters))
+    static let quotationChars:  Set<Character> = Set("'\"".characters)
+    static let listChars:       Set<Character> = Set("()".characters)
+    static let protectedChars = [whitespaceChars, quotationChars, listChars].reduce(Set()) { $0.union($1) }
+    
     static let digitChars: Set<Character> = Set("0123456789".characters)
-    static let integerChars = Parser.digitChars
     static let decimalSeparatorChar: Character = "."
-    static let decimalChars = Parser.digitChars.union(Set([Parser.decimalSeparatorChar]))
     static let divisionOperatorChar: Character = "/"
-    static let rationalChars = Parser.digitChars.union(Set([Parser.divisionOperatorChar]))
-    static let numberChars = Parser.decimalChars.union(Parser.rationalChars)
+    static let integerChars  = digitChars
+    static let decimalChars  = digitChars.union(Set([decimalSeparatorChar]))
+    static let rationalChars = digitChars.union(Set([divisionOperatorChar]))
+    static let numberChars   = [integerChars, decimalChars, rationalChars].reduce(Set()) { $0.union($1) }
     
     // MARK: Lexical level
     

--- a/SwiftExP/Parser.swift
+++ b/SwiftExP/Parser.swift
@@ -306,7 +306,7 @@ extension Character {
             case "d", "D": return 13
             case "e", "E": return 14
             case "f", "F": return 15
-        default:       throw Error.IllegalHexCharacter(char: self)
+            default:       throw Error.IllegalHexCharacter(char: self)
         }
     }
 }

--- a/SwiftExP/Parser.swift
+++ b/SwiftExP/Parser.swift
@@ -94,11 +94,8 @@ public struct Parser {
     public mutating func parse() throws -> Expression {
         do {
             return try parseExpression()!
-        } catch let error where error is Scanner.Error {
-            switch (error as! Scanner.Error) {
-                case .EOS:
-                    throw Error.UnexpectedEOS
-            }
+        } catch Scanner.Error.EOS {
+            throw Error.UnexpectedEOS
         }
     }
     

--- a/SwiftExP/Parser.swift
+++ b/SwiftExP/Parser.swift
@@ -217,8 +217,8 @@ public struct Parser {
     static let decimalSeparatorChar: Character = "."
     static let divisionOperatorChar: Character = "/"
     static let integerChars  = digitChars
-    static let decimalChars  = digitChars.union(Set([decimalSeparatorChar]))
-    static let rationalChars = digitChars.union(Set([divisionOperatorChar]))
+    static let decimalChars  = digitChars.union([decimalSeparatorChar])
+    static let rationalChars = digitChars.union([divisionOperatorChar])
     static let numberChars   = [integerChars, decimalChars, rationalChars].reduce(Set()) { $0.union($1) }
     
     // MARK: Lexical level

--- a/SwiftExP/Parser.swift
+++ b/SwiftExP/Parser.swift
@@ -23,20 +23,14 @@ extension Error : Equatable {
 
 public func ==(lhs: Error, rhs: Error) -> Bool {
     switch (lhs, rhs) {
-        case (.UnexpectedEOS, .UnexpectedEOS):
-            return true
         case (.IllegalNumberFormat(let l), .IllegalNumberFormat(let r)):
             return l == r
         case (.IllegalEscapeSequence(let l), .IllegalEscapeSequence(let r)):
             return l == r
-        case (.NonTerminatedList, .NonTerminatedList):
-            return true
-        case (.NonTerminatedQuotedString, .NonTerminatedQuotedString):
-            return true
         case (.IllegalHexCharacter(let l), .IllegalHexCharacter(let r)):
             return l == r
         default:
-            return false
+            return lhs._code == rhs._code
     }
 }
 

--- a/SwiftExP/Parser.swift
+++ b/SwiftExP/Parser.swift
@@ -173,32 +173,26 @@ public struct Parser {
     }
     
     func parseRational(string: String) throws -> Atom {
-        let (maybeNumeratorStr, denominatorStr) = string.readUntil(Parser.divisionOperatorChar)
-        if denominatorStr.isEmpty {
+        guard let (numeratorStr, denominatorStr) = string.readUntil(Parser.divisionOperatorChar)
+            where !denominatorStr.isEmpty else {
             throw Error.IllegalNumberFormat(numberString: string)
         }
-        if let numeratorStr = maybeNumeratorStr {
-            let numerator = Int(numeratorStr)!
-            let denominator = Int(denominatorStr)!
-            return .Decimal(Double(numerator) / Double(denominator))
-        } else {
-            throw Scanner.Error.EOS
-        }
+
+        let numerator = Int(numeratorStr)!
+        let denominator = Int(denominatorStr)!
+        return .Decimal(Double(numerator) / Double(denominator))
     }
     
     func parseDecimal(string: String) throws -> Atom {
-        let (maybeDecimalStr, mantissaStr) = string.readUntil(Parser.decimalSeparatorChar)
-        if mantissaStr.isEmpty {
+        guard let (decimalStr, mantissaStr) = string.readUntil(Parser.decimalSeparatorChar)
+            where !mantissaStr.isEmpty else {
             throw Error.IllegalNumberFormat(numberString: string)
         }
-        if let decimalStr = maybeDecimalStr {
-            let decimal = Int(decimalStr)!
-            let mantissa = Int(mantissaStr)!
-            let divident = (0 ..< Int(mantissaStr.characters.count)).reduce(1) { (a: Int, _) in return a * 10 }
-            return .Decimal(Double(decimal) + (Double(mantissa) / Double(divident)))
-        } else {
-            throw Scanner.Error.EOS
-        }
+
+        let decimal = Int(decimalStr)!
+        let mantissa = Int(mantissaStr)!
+        let divident = (0 ..< Int(mantissaStr.characters.count)).reduce(1) { (a: Int, _) in return a * 10 }
+        return .Decimal(Double(decimal) + (Double(mantissa) / Double(divident)))
     }
     
     static let assignmentChar: Character = "="

--- a/SwiftExP/Parser.swift
+++ b/SwiftExP/Parser.swift
@@ -72,7 +72,7 @@ public struct Parser {
     - parameter string  The string to parse
     */
     public static func parse(string: String) throws -> Expression {
-        var parser = self(string: string)
+        var parser = self.init(string: string)
         return try parser.parse()
     }
     

--- a/SwiftExP/Scanner.swift
+++ b/SwiftExP/Scanner.swift
@@ -87,12 +87,12 @@ extension String {
     
     - parameter char  The character until which should be read
     */
-    public func readUntil(char: Character) -> (substring: String?, remainder: String) {
-        let parts = self.characters.split(char, maxSplit: 1, allowEmptySlices: false)
+    public func readUntil(char: Character) -> (substring: String, remainder: String)? {
+        let parts = self.characters.split(char, maxSplit: 2, allowEmptySlices: false)
         if parts.count > 1 {
             return (String(parts[0]), String(parts[1]))
         } else {
-            return (nil, self)
+            return nil
         }
     }
 }

--- a/SwiftExP/Scanner.swift
+++ b/SwiftExP/Scanner.swift
@@ -61,7 +61,7 @@ public struct Scanner {
         if eos {
             throw Error.EOS
         } else {
-            index = advance(index, 1)
+            index = index.advancedBy(1)
         }
     }
     
@@ -70,8 +70,8 @@ public struct Scanner {
     throws an error when the end of string is reached before.
     */
     public mutating func readChars(length: Int) throws -> String {
-        let advancedIndex = advance(index, length, string.endIndex)
-        if distance(index, advancedIndex) < length {
+        let advancedIndex = index.advancedBy(length, limit: string.endIndex)
+        if index.distanceTo(advancedIndex) < length {
             throw Error.EOS
         }
         let chars = string[index..<advancedIndex]

--- a/SwiftExP/Scanner.swift
+++ b/SwiftExP/Scanner.swift
@@ -88,7 +88,7 @@ extension String {
     - parameter char  The character until which should be read
     */
     public func readUntil(char: Character) -> (substring: String?, remainder: String) {
-        let parts = split(self.characters, maxSplit: 1, allowEmptySlices: false) { $0 == char }
+        let parts = self.characters.split(char, maxSplit: 1, allowEmptySlices: false)
         if parts.count > 1 {
             return (String(parts[0]), String(parts[1]))
         } else {

--- a/SwiftExPTests/Fixtures/test.reserialized.swift-ast
+++ b/SwiftExPTests/Fixtures/test.reserialized.swift-ast
@@ -1,0 +1,21 @@
+(source_file
+  (var_decl a type=Bool access=internal let storage_kind=stored)
+  (top_level_code_decl
+    (brace_stmt
+      (pattern_binding_decl
+        (pattern_named type=Bool a)
+        (prefix_unary_expr type=Bool location=a.swift:1:9 range="[a.swift:1:9 - line:1:10]"
+          (declref_expr type="(Bool) -> Bool" location=a.swift:1:9 range="[a.swift:1:9 - line:1:9]" decl="Swift.(file).!" specialized=no)
+          (call_expr implicit type=Bool location=a.swift:1:10 range="[a.swift:1:10 - line:1:10]"
+            (constructor_ref_call_expr implicit type="(_builtinBooleanLiteral: Int1) -> Bool" location=a.swift:1:10 range="[a.swift:1:10 - line:1:10]"
+              (declref_expr implicit type="Bool.Type -> (_builtinBooleanLiteral: Int1) -> Bool" location=a.swift:1:10 range="[a.swift:1:10 - line:1:10]" decl="Swift.(file).Bool.init(_builtinBooleanLiteral:)" specialized=no)
+              (type_expr implicit type=Bool.Type location=a.swift:1:10 range="[a.swift:1:10 - line:1:10]" typerepr=<<IMPLICIT>>))
+            (tuple_expr implicit type="(_builtinBooleanLiteral: Builtin.Int1)" location=a.swift:1:10 range="[a.swift:1:10 - line:1:10]" names=_builtinBooleanLiteral
+              (boolean_literal_expr type=Builtin.Int1 location=a.swift:1:10 range="[a.swift:1:10 - line:1:10]" value=true)))))))
+  (var_decl b type=Int access=internal let storage_kind=stored)
+  (top_level_code_decl
+    (brace_stmt
+      (pattern_binding_decl
+        (pattern_named type=Int b)
+        (forced_checked_cast_expr type=Int location=a.swift:1:26 range="[a.swift:1:24 - line:1:30]" value_cast writtenType=Int
+          (declref_expr type=Bool location=a.swift:1:24 range="[a.swift:1:24 - line:1:24]" decl="a.(file).a@a.swift:1:5" direct_to_storage specialized=no))))))

--- a/SwiftExPTests/Fixtures/test.swift-ast
+++ b/SwiftExPTests/Fixtures/test.swift-ast
@@ -1,0 +1,23 @@
+(source_file
+  (var_decl "a" type='Bool' access=internal let storage_kind=stored)
+  (top_level_code_decl
+    (brace_stmt
+      (pattern_binding_decl
+        (pattern_named type='Bool' 'a')
+        (prefix_unary_expr type='Bool' location=a.swift:1:9 range=[a.swift:1:9 - line:1:10]
+          (declref_expr type='(Bool) -> Bool' location=a.swift:1:9 range=[a.swift:1:9 - line:1:9] decl=Swift.(file).! specialized=no)
+          (call_expr implicit type='Bool' location=a.swift:1:10 range=[a.swift:1:10 - line:1:10]
+            (constructor_ref_call_expr implicit type='(_builtinBooleanLiteral: Int1) -> Bool' location=a.swift:1:10 range=[a.swift:1:10 - line:1:10]
+              (declref_expr implicit type='Bool.Type -> (_builtinBooleanLiteral: Int1) -> Bool' location=a.swift:1:10 range=[a.swift:1:10 - line:1:10] decl=Swift.(file).Bool.init(_builtinBooleanLiteral:) specialized=no)
+              (type_expr implicit type='Bool.Type' location=a.swift:1:10 range=[a.swift:1:10 - line:1:10] typerepr='<<IMPLICIT>>'))
+            (tuple_expr implicit type='(_builtinBooleanLiteral: Builtin.Int1)' location=a.swift:1:10 range=[a.swift:1:10 - line:1:10] names=_builtinBooleanLiteral
+              (boolean_literal_expr type='Builtin.Int1' location=a.swift:1:10 range=[a.swift:1:10 - line:1:10] value=true)))))
+))
+  (var_decl "b" type='Int' access=internal let storage_kind=stored)
+  (top_level_code_decl
+    (brace_stmt
+      (pattern_binding_decl
+        (pattern_named type='Int' 'b')
+        (forced_checked_cast_expr type='Int' location=a.swift:1:26 range=[a.swift:1:24 - line:1:30] value_cast writtenType=Int
+          (declref_expr type='Bool' location=a.swift:1:24 range=[a.swift:1:24 - line:1:24] decl=a.(file).a@a.swift:1:5 direct_to_storage specialized=no)))
+)))

--- a/SwiftExPTests/ModelTests.swift
+++ b/SwiftExPTests/ModelTests.swift
@@ -35,4 +35,8 @@ class ModelTests: XCTestCase {
         assertDescription(.List([.Atom(.String("a")), .Atom(.String("b"))]), "(\"a\" \"b\")")
     }
     
+    func testAttribute() {
+        assertDescription(Expression(.String("a"), Expression(1)), "\"a\"=1")
+    }
+    
 }

--- a/SwiftExPTests/ModelTests.swift
+++ b/SwiftExPTests/ModelTests.swift
@@ -16,7 +16,7 @@ private func assertDescription(expression: Expression, _ description: String) {
 class ModelTests: XCTestCase {
     
     func testString() {
-        assertDescription(.Atom(.String("a")),    "\"a\"")
+        assertDescription(.Atom(.String("a")),    "a")
         assertDescription(.Atom(.String("a b")),  "\"a b\"")
         assertDescription(.Atom(.String("a\"b")), "\"a\\\"b\"")
     }
@@ -32,11 +32,12 @@ class ModelTests: XCTestCase {
     }
     
     func testList() {
-        assertDescription(.List([.Atom(.String("a")), .Atom(.String("b"))]), "(\"a\" \"b\")")
+        assertDescription(.List([.Atom(.String("a")), .Atom(.String("b"))]), "(a b)")
     }
     
     func testAttribute() {
-        assertDescription(Expression(.String("a"), Expression(1)), "\"a\"=1")
+        assertDescription(Expression(.String("a"), Expression(1)),   "a=1")
+        assertDescription(Expression(.String("a b"), Expression(1)), "\"a b\"=1")
     }
     
 }

--- a/SwiftExPTests/ModelTests.swift
+++ b/SwiftExPTests/ModelTests.swift
@@ -16,23 +16,23 @@ private func assertDescription(expression: Expression, _ description: String) {
 class ModelTests: XCTestCase {
     
     func testString() {
-        assertDescription(.StringAtom("a"),    "\"a\"")
-        assertDescription(.StringAtom("a b"),  "\"a b\"")
-        assertDescription(.StringAtom("a\"b"), "\"a\\\"b\"")
+        assertDescription(.Atom(.String("a")),    "\"a\"")
+        assertDescription(.Atom(.String("a b")),  "\"a b\"")
+        assertDescription(.Atom(.String("a\"b")), "\"a\\\"b\"")
     }
     
     func testDecimal() {
-        assertDescription(.DecimalAtom(0.5),       "0.5")
-        assertDescription(.DecimalAtom(13.37),     "13.37")
-        assertDescription(.DecimalAtom(1.0 / 3.0), "0.333333333333333")
+        assertDescription(.Atom(.Decimal(0.5)),       "0.5")
+        assertDescription(.Atom(.Decimal(13.37)),     "13.37")
+        assertDescription(.Atom(.Decimal(1.0 / 3.0)), "0.333333333333333")
     }
     
     func testInteger() {
-        assertDescription(.IntegerAtom(1), "1")
+        assertDescription(.Atom(.Integer(1)), "1")
     }
     
     func testList() {
-        assertDescription(.List([.StringAtom("a"), .StringAtom("b")]), "(\"a\" \"b\")")
+        assertDescription(.List([.Atom(.String("a")), .Atom(.String("b"))]), "(\"a\" \"b\")")
     }
     
 }

--- a/SwiftExPTests/ParserTests.swift
+++ b/SwiftExPTests/ParserTests.swift
@@ -159,4 +159,13 @@ class ParserTests: XCTestCase {
         SWEXPThrow(Error.IllegalHexCharacter(char: " "), try Parser.parse("\"\\u    \""))
     }
     
+    // MARK: Fixtures
+    
+    func test_301_swiftAstDump() {
+        let bundle = NSBundle(forClass: ParserTests.self)
+        let path = bundle.pathForResource("test", ofType: "swift-ast")!
+        let expr = try! Parser.parse(contentsOfFile: path)
+        XCTAssertEqual(String(expr), "")
+    }
+    
 }

--- a/SwiftExPTests/ParserTests.swift
+++ b/SwiftExPTests/ParserTests.swift
@@ -33,108 +33,125 @@ func SWXPAssertNoThrow(file: String = __FILE__, line: UInt = __LINE__, @noescape
     }
 }
 
+func SWXPAssertNoThrow<T>(@autoclosure closure: () throws -> (T), file: String = __FILE__, line: UInt = __LINE__) -> T? {
+    do {
+        return try closure()
+    } catch {
+        XCTFail("Catched unexpected error \"\(error)\".", file: file, line: line)
+    }
+    return nil
+}
+
+
+public func SWXPAssertEqual<T : Equatable>(@autoclosure expression1: () throws -> T?, @autoclosure _ expression2: () throws -> T?, _ message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
+    let exp1 = SWXPAssertNoThrow(expression1, file: file, line: line) ?? nil
+    let exp2 = SWXPAssertNoThrow(expression2, file: file, line: line) ?? nil
+    XCTAssertEqual(exp1, exp2, message, file: file, line: line)
+}
+
+
 class ParserTests: XCTestCase {
     
     // MARK: Atoms
     
     func test_001_int() {
-        XCTAssertEqual(try! Parser.parse("1"), Expression(1))
+        SWXPAssertEqual(try Parser.parse("1"), Expression(1))
     }
     
     func test_002_rational() {
-        XCTAssertEqual(try! Parser.parse("1/2"), Expression(0.5))
+        SWXPAssertEqual(try Parser.parse("1/2"), Expression(0.5))
     }
     
     func test_003_decimal() {
-        XCTAssertEqual(try! Parser.parse("1.23"), Expression(1.23))
+        SWXPAssertEqual(try Parser.parse("1.23"), Expression(1.23))
     }
     
     func test_004_string() {
-        XCTAssertEqual(try! Parser.parse("a"),  Expression("a"))
-        XCTAssertEqual(try! Parser.parse("ab"), Expression("ab"))
+        SWXPAssertEqual(try Parser.parse("a"),  Expression("a"))
+        SWXPAssertEqual(try Parser.parse("ab"), Expression("ab"))
     }
     
     func test_005_quotedEmptyString() {
-        XCTAssertEqual(try! Parser.parse("\"\""),  Expression(""))
+        SWXPAssertEqual(try Parser.parse("\"\""),  Expression(""))
     }
     
     func test_006_quotedString() {
-        XCTAssertEqual(try! Parser.parse("\"a\""), Expression("a"))
+        SWXPAssertEqual(try Parser.parse("\"a\""), Expression("a"))
     }
     
     func test_006_quotedEscapedQuotationMark() {
-        XCTAssertEqual(try! Parser.parse("\"\\\"\""), Expression("\""))
+        SWXPAssertEqual(try Parser.parse("\"\\\"\""), Expression("\""))
     }
     
     func test_007_quotedSingleEscapeSequence() {
-        XCTAssertEqual(try! Parser.parse("\"\\t\""),  Expression("\t"))
-        XCTAssertEqual(try! Parser.parse("\"\\n\""),  Expression("\n"))
-        XCTAssertEqual(try! Parser.parse("\"\\r\""),  Expression("\r"))
-        XCTAssertEqual(try! Parser.parse("\"\\'\""),  Expression("'"))
-        XCTAssertEqual(try! Parser.parse("\"\\\\\""), Expression("\\"))
-        XCTAssertEqual(try! Parser.parse("\"\\b\""),  Expression("\u{8}")) // backspace
-        XCTAssertEqual(try! Parser.parse("\"\\v\""),  Expression("\u{b}")) // vertical tab
-        XCTAssertEqual(try! Parser.parse("\"\\f\""),  Expression("\u{c}")) // form-feed
+        SWXPAssertEqual(try Parser.parse("\"\\t\""),  Expression("\t"))
+        SWXPAssertEqual(try Parser.parse("\"\\n\""),  Expression("\n"))
+        SWXPAssertEqual(try Parser.parse("\"\\r\""),  Expression("\r"))
+        SWXPAssertEqual(try Parser.parse("\"\\'\""),  Expression("'"))
+        SWXPAssertEqual(try Parser.parse("\"\\\\\""), Expression("\\"))
+        SWXPAssertEqual(try Parser.parse("\"\\b\""),  Expression("\u{8}")) // backspace
+        SWXPAssertEqual(try Parser.parse("\"\\v\""),  Expression("\u{b}")) // vertical tab
+        SWXPAssertEqual(try Parser.parse("\"\\f\""),  Expression("\u{c}")) // form-feed
     }
     
     func test_008_quotedUnicodeEscapeSequence() {
-        XCTAssertEqual(try! Parser.parse("\"\\u2713\""), Expression("✓"))
-        XCTAssertEqual(try! Parser.parse("\"\\U0001F1FA\\U0001F1F8\""), Expression("🇺🇸"))
+        SWXPAssertEqual(try Parser.parse("\"\\u2713\""), Expression("✓"))
+        SWXPAssertEqual(try Parser.parse("\"\\U0001F1FA\\U0001F1F8\""), Expression("🇺🇸"))
     }
     
     func test_009_quotedNonEscapedLineWraps() {
-        XCTAssertEqual(try! Parser.parse("\"\n\""),   Expression("\n"))
-        XCTAssertEqual(try! Parser.parse("\"\n\r\""), Expression("\n\r"))
-        XCTAssertEqual(try! Parser.parse("\"\r\""),   Expression("\r"))
-        XCTAssertEqual(try! Parser.parse("\"\r\n\""), Expression("\r\n"))
+        SWXPAssertEqual(try Parser.parse("\"\n\""),   Expression("\n"))
+        SWXPAssertEqual(try Parser.parse("\"\n\r\""), Expression("\n\r"))
+        SWXPAssertEqual(try Parser.parse("\"\r\""),   Expression("\r"))
+        SWXPAssertEqual(try Parser.parse("\"\r\n\""), Expression("\r\n"))
     }
         
     func test_009_quotedEscapedLineWraps() {
-        XCTAssertEqual(try! Parser.parse("\"\\\n\""),   Expression(""))
-        XCTAssertEqual(try! Parser.parse("\"\\\n\r\""), Expression(""))
-        XCTAssertEqual(try! Parser.parse("\"\\\r\""),   Expression(""))
+        SWXPAssertEqual(try Parser.parse("\"\\\n\""),   Expression(""))
+        SWXPAssertEqual(try Parser.parse("\"\\\n\r\""), Expression(""))
+        SWXPAssertEqual(try Parser.parse("\"\\\r\""),   Expression(""))
         // TODO: Doesn't work
-        //XCTAssertEqual(try! Parser.parse("\"\\\r\n\""), Expression(""))
+        //SWXPAssertEqual(try Parser.parse("\"\\\r\n\""), Expression(""))
     }
     
     func test_010_maintainedQuotationChars() {
-        XCTAssertEqual(try! Parser.parse("[a b]"), Expression("[a b]"))
+        SWXPAssertEqual(try Parser.parse("[a b]"), Expression("[a b]"))
     }
     
     // MARK: Lists
     
     func test_101_emptyList() {
-        XCTAssertEqual(try! Parser.parse("()"),  Expression([]))
-        XCTAssertEqual(try! Parser.parse("( )"), Expression([]))
+        SWXPAssertEqual(try Parser.parse("()"),  Expression([]))
+        SWXPAssertEqual(try Parser.parse("( )"), Expression([]))
     }
     
     func test_102_listOfLists() {
-        XCTAssertEqual(try! Parser.parse("(()())"), Expression([
+        SWXPAssertEqual(try Parser.parse("(()())"), Expression([
             .List([]),
             .List([]),
         ]))
-        XCTAssertEqual(try! Parser.parse("(() ())"), Expression([
+        SWXPAssertEqual(try Parser.parse("(() ())"), Expression([
             .List([]),
             .List([]),
         ]))
     }
     
     func test_103_listOfStrings() {
-        XCTAssertEqual(try! Parser.parse("(a b)"), Expression([
+        SWXPAssertEqual(try Parser.parse("(a b)"), Expression([
             Expression("a"),
             Expression("b")
         ]))
     }
     
     func test_104_listOfListOfStrings() {
-        XCTAssertEqual(try! Parser.parse("((a b) (c d))"), Expression([
+        SWXPAssertEqual(try Parser.parse("((a b) (c d))"), Expression([
             .List([Expression("a"), Expression("b")]),
             .List([Expression("c"), Expression("d")]),
         ]))
     }
     
     func test_105_listOfListOfStrings() {
-        XCTAssertEqual(try! Parser.parse("(( a ) (b))"), Expression([
+        SWXPAssertEqual(try Parser.parse("(( a ) (b))"), Expression([
             .List([Expression("a")]),
             .List([Expression("b")]),
         ]))
@@ -143,7 +160,7 @@ class ParserTests: XCTestCase {
     // MARK: Assignment
     
     func test_211_assignment() {
-        XCTAssertEqual(try! Parser.parse("\"a\"=1"), Expression(Atom.String("a"), Expression(1)))
+        SWXPAssertEqual(try Parser.parse("\"a\"=1"), Expression(Atom.String("a"), Expression(1)))
     }
     
     // MARK: Errors
@@ -184,7 +201,7 @@ class ParserTests: XCTestCase {
     func test_207_illegalHexCharacter() {
         SWXPAssertThrow(Error.IllegalHexCharacter(char: "x"), try Parser.parse("\"\\uxxxx\""))
         SWXPAssertThrow(Error.IllegalHexCharacter(char: " "), try Parser.parse("\"\\u    \""))
-        SWXPAssertThrows(Error.IllegalHexCharacter(char: " ")) { try Parser.parse("\"\\u    \"") }
+        SWXPAssertThrow(Error.IllegalHexCharacter(char: " "), try Parser.parse("\"\\u    \""))
     }
     
     // MARK: Fixtures

--- a/SwiftExPTests/ParserTests.swift
+++ b/SwiftExPTests/ParserTests.swift
@@ -86,6 +86,10 @@ class ParserTests: XCTestCase {
         //XCTAssertEqual(try! Parser.parse("\"\\\r\n\""), Expression(""))
     }
     
+    func test_010_maintainedQuotationChars() {
+        XCTAssertEqual(try! Parser.parse("[a b]"), Expression("[a b]"))
+    }
+    
     // MARK: Lists
     
     func test_101_emptyList() {

--- a/SwiftExPTests/ParserTests.swift
+++ b/SwiftExPTests/ParserTests.swift
@@ -15,8 +15,8 @@ func SWEXPThrow(expectedError: Error, @autoclosure _ closure: () throws -> (Expr
         XCTFail("Expected error \"\(expectedError)\", but succeeded with value "
             + "\(unexpectedValue)\".")
     } catch let error where error is Error {
-        XCTAssertTrue(error as! Error == expectedError, "Catched error \"\(error)\" from expected type, "
-            + "but not the expected case: \"\(expectedError)\"")
+        XCTAssertEqual(error as! Error, expectedError, "Catched error is from expected type, "
+            + "but not the expected case.")
     } catch {
         XCTFail("Catched error \"\(error)\", but not the expected type: \"\(expectedError)\"")
     }

--- a/SwiftExPTests/ParserTests.swift
+++ b/SwiftExPTests/ParserTests.swift
@@ -25,6 +25,14 @@ func SWXPAssertThrow<E, T where E: Equatable>(expectedError: E, @autoclosure _ c
 }
 
 
+func SWXPAssertNoThrow(file: String = __FILE__, line: UInt = __LINE__, @noescape closure: () throws -> ()) {
+    do {
+        try closure()
+    } catch {
+        XCTFail("Catched unexpected error \"\(error)\".", file: file, line: line)
+    }
+}
+
 class ParserTests: XCTestCase {
     
     // MARK: Atoms
@@ -184,8 +192,10 @@ class ParserTests: XCTestCase {
     func test_301_swiftAstDump() {
         let bundle = NSBundle(forClass: ParserTests.self)
         let path = bundle.pathForResource("test", ofType: "swift-ast")!
-        let expr = try! Parser.parse(contentsOfFile: path)
-        XCTAssertEqual(String(expr), "")
+        SWXPAssertNoThrow {
+            let expr = try Parser.parse(contentsOfFile: path)
+            SWXPAssertEqual(String(expr), "")
+        }
     }
     
 }

--- a/SwiftExPTests/ParserTests.swift
+++ b/SwiftExPTests/ParserTests.swift
@@ -160,7 +160,8 @@ class ParserTests: XCTestCase {
     // MARK: Assignment
     
     func test_211_assignment() {
-        SWXPAssertEqual(try Parser.parse("\"a\"=1"), Expression(Atom.String("a"), Expression(1)))
+        SWXPAssertEqual(try Parser.parse("\"a\"=1"),     Expression(Atom.String("a"), Expression(1)))
+        SWXPAssertEqual(try Parser.parse("\"a\"=b(c)d"), Expression(Atom.String("a"), Expression("b(c)d")))
     }
     
     // MARK: Errors

--- a/SwiftExPTests/ParserTests.swift
+++ b/SwiftExPTests/ParserTests.swift
@@ -26,63 +26,63 @@ class ParserTests: XCTestCase {
     // MARK: Atoms
     
     func test_001_int() {
-        XCTAssertEqual(try! Parser.parse("1"), .IntegerAtom(1))
+        XCTAssertEqual(try! Parser.parse("1"), Expression(1))
     }
     
     func test_002_rational() {
-        XCTAssertEqual(try! Parser.parse("1/2"), .DecimalAtom(0.5))
+        XCTAssertEqual(try! Parser.parse("1/2"), Expression(0.5))
     }
     
     func test_003_decimal() {
-        XCTAssertEqual(try! Parser.parse("1.23"), .DecimalAtom(1.23))
+        XCTAssertEqual(try! Parser.parse("1.23"), Expression(1.23))
     }
     
     func test_004_string() {
-        XCTAssertEqual(try! Parser.parse("a"),  .StringAtom("a"))
-        XCTAssertEqual(try! Parser.parse("ab"), .StringAtom("ab"))
+        XCTAssertEqual(try! Parser.parse("a"),  Expression("a"))
+        XCTAssertEqual(try! Parser.parse("ab"), Expression("ab"))
     }
     
     func test_005_quotedEmptyString() {
-        XCTAssertEqual(try! Parser.parse("\"\""),  .StringAtom(""))
+        XCTAssertEqual(try! Parser.parse("\"\""),  Expression(""))
     }
     
     func test_006_quotedString() {
-        XCTAssertEqual(try! Parser.parse("\"a\""), .StringAtom("a"))
+        XCTAssertEqual(try! Parser.parse("\"a\""), Expression("a"))
     }
     
     func test_006_quotedEscapedQuotationMark() {
-        XCTAssertEqual(try! Parser.parse("\"\\\"\""), .StringAtom("\""))
+        XCTAssertEqual(try! Parser.parse("\"\\\"\""), Expression("\""))
     }
     
     func test_007_quotedSingleEscapeSequence() {
-        XCTAssertEqual(try! Parser.parse("\"\\t\""),  .StringAtom("\t"))
-        XCTAssertEqual(try! Parser.parse("\"\\n\""),  .StringAtom("\n"))
-        XCTAssertEqual(try! Parser.parse("\"\\r\""),  .StringAtom("\r"))
-        XCTAssertEqual(try! Parser.parse("\"\\'\""),  .StringAtom("'"))
-        XCTAssertEqual(try! Parser.parse("\"\\\\\""), .StringAtom("\\"))
-        XCTAssertEqual(try! Parser.parse("\"\\b\""),  .StringAtom("\u{8}")) // backspace
-        XCTAssertEqual(try! Parser.parse("\"\\v\""),  .StringAtom("\u{b}")) // vertical tab
-        XCTAssertEqual(try! Parser.parse("\"\\f\""),  .StringAtom("\u{c}")) // form-feed
+        XCTAssertEqual(try! Parser.parse("\"\\t\""),  Expression("\t"))
+        XCTAssertEqual(try! Parser.parse("\"\\n\""),  Expression("\n"))
+        XCTAssertEqual(try! Parser.parse("\"\\r\""),  Expression("\r"))
+        XCTAssertEqual(try! Parser.parse("\"\\'\""),  Expression("'"))
+        XCTAssertEqual(try! Parser.parse("\"\\\\\""), Expression("\\"))
+        XCTAssertEqual(try! Parser.parse("\"\\b\""),  Expression("\u{8}")) // backspace
+        XCTAssertEqual(try! Parser.parse("\"\\v\""),  Expression("\u{b}")) // vertical tab
+        XCTAssertEqual(try! Parser.parse("\"\\f\""),  Expression("\u{c}")) // form-feed
     }
     
     func test_008_quotedUnicodeEscapeSequence() {
-        XCTAssertEqual(try! Parser.parse("\"\\u2713\""), .StringAtom("✓"))
-        XCTAssertEqual(try! Parser.parse("\"\\U0001F1FA\\U0001F1F8\""), .StringAtom("🇺🇸"))
+        XCTAssertEqual(try! Parser.parse("\"\\u2713\""), Expression("✓"))
+        XCTAssertEqual(try! Parser.parse("\"\\U0001F1FA\\U0001F1F8\""), Expression("🇺🇸"))
     }
     
     func test_009_quotedNonEscapedLineWraps() {
-        XCTAssertEqual(try! Parser.parse("\"\n\""),   .StringAtom("\n"))
-        XCTAssertEqual(try! Parser.parse("\"\n\r\""), .StringAtom("\n\r"))
-        XCTAssertEqual(try! Parser.parse("\"\r\""),   .StringAtom("\r"))
-        XCTAssertEqual(try! Parser.parse("\"\r\n\""), .StringAtom("\r\n"))
+        XCTAssertEqual(try! Parser.parse("\"\n\""),   Expression("\n"))
+        XCTAssertEqual(try! Parser.parse("\"\n\r\""), Expression("\n\r"))
+        XCTAssertEqual(try! Parser.parse("\"\r\""),   Expression("\r"))
+        XCTAssertEqual(try! Parser.parse("\"\r\n\""), Expression("\r\n"))
     }
         
     func test_009_quotedEscapedLineWraps() {
-        XCTAssertEqual(try! Parser.parse("\"\\\n\""),   .StringAtom(""))
-        XCTAssertEqual(try! Parser.parse("\"\\\n\r\""), .StringAtom(""))
-        XCTAssertEqual(try! Parser.parse("\"\\\r\""),   .StringAtom(""))
+        XCTAssertEqual(try! Parser.parse("\"\\\n\""),   Expression(""))
+        XCTAssertEqual(try! Parser.parse("\"\\\n\r\""), Expression(""))
+        XCTAssertEqual(try! Parser.parse("\"\\\r\""),   Expression(""))
         // TODO: Doesn't work
-        //XCTAssertEqual(try! Parser.parse("\"\\\r\n\""), .StringAtom(""))
+        //XCTAssertEqual(try! Parser.parse("\"\\\r\n\""), Expression(""))
     }
     
     // MARK: Lists
@@ -105,22 +105,22 @@ class ParserTests: XCTestCase {
     
     func test_103_listOfStrings() {
         XCTAssertEqual(try! Parser.parse("(a b)"), .List([
-            .StringAtom("a"),
-            .StringAtom("b")
+            Expression("a"),
+            Expression("b")
         ]))
     }
     
     func test_104_listOfListOfStrings() {
         XCTAssertEqual(try! Parser.parse("((a b) (c d))"), .List([
-            .List([.StringAtom("a"), .StringAtom("b")]),
-            .List([.StringAtom("c"), .StringAtom("d")]),
+            .List([Expression("a"), Expression("b")]),
+            .List([Expression("c"), Expression("d")]),
         ]))
     }
     
     func test_105_listOfListOfStrings() {
         XCTAssertEqual(try! Parser.parse("(( a ) (b))"), .List([
-            .List([.StringAtom("a")]),
-            .List([.StringAtom("b")]),
+            .List([Expression("a")]),
+            .List([Expression("b")]),
         ]))
     }
     

--- a/SwiftExPTests/ParserTests.swift
+++ b/SwiftExPTests/ParserTests.swift
@@ -11,11 +11,12 @@ import SwiftExP
 
 func SWEXPThrow(expectedError: Error, @autoclosure _ closure: () throws -> (Expression)) -> () {
     do {
-        let _ = try closure()
-        XCTFail("Expected error \"\(expectedError)\", but succeeded")
+        let unexpectedValue = try closure()
+        XCTFail("Expected error \"\(expectedError)\", but succeeded with value "
+            + "\(unexpectedValue)\".")
     } catch let error where error is Error {
         XCTAssertTrue(error as! Error == expectedError, "Catched error \"\(error)\" from expected type, "
-            + "but not the expected value: \"\(expectedError)\"")
+            + "but not the expected case: \"\(expectedError)\"")
     } catch {
         XCTFail("Catched error \"\(error)\", but not the expected type: \"\(expectedError)\"")
     }

--- a/SwiftExPTests/ParserTests.swift
+++ b/SwiftExPTests/ParserTests.swift
@@ -93,37 +93,37 @@ class ParserTests: XCTestCase {
     // MARK: Lists
     
     func test_101_emptyList() {
-        XCTAssertEqual(try! Parser.parse("()"), .List([]))
-        XCTAssertEqual(try! Parser.parse("( )"), .List([]))
+        XCTAssertEqual(try! Parser.parse("()"),  Expression([]))
+        XCTAssertEqual(try! Parser.parse("( )"), Expression([]))
     }
     
     func test_102_listOfLists() {
-        XCTAssertEqual(try! Parser.parse("(()())"), .List([
+        XCTAssertEqual(try! Parser.parse("(()())"), Expression([
             .List([]),
             .List([]),
         ]))
-        XCTAssertEqual(try! Parser.parse("(() ())"), .List([
+        XCTAssertEqual(try! Parser.parse("(() ())"), Expression([
             .List([]),
             .List([]),
         ]))
     }
     
     func test_103_listOfStrings() {
-        XCTAssertEqual(try! Parser.parse("(a b)"), .List([
+        XCTAssertEqual(try! Parser.parse("(a b)"), Expression([
             Expression("a"),
             Expression("b")
         ]))
     }
     
     func test_104_listOfListOfStrings() {
-        XCTAssertEqual(try! Parser.parse("((a b) (c d))"), .List([
+        XCTAssertEqual(try! Parser.parse("((a b) (c d))"), Expression([
             .List([Expression("a"), Expression("b")]),
             .List([Expression("c"), Expression("d")]),
         ]))
     }
     
     func test_105_listOfListOfStrings() {
-        XCTAssertEqual(try! Parser.parse("(( a ) (b))"), .List([
+        XCTAssertEqual(try! Parser.parse("(( a ) (b))"), Expression([
             .List([Expression("a")]),
             .List([Expression("b")]),
         ]))

--- a/SwiftExPTests/ParserTests.swift
+++ b/SwiftExPTests/ParserTests.swift
@@ -125,6 +125,12 @@ class ParserTests: XCTestCase {
         ]))
     }
     
+    // MARK: Assignment
+    
+    func test_211_assignment() {
+        XCTAssertEqual(try! Parser.parse("\"a\"=1"), Expression(Atom.String("a"), Expression(1)))
+    }
+    
     // MARK: Errors
 
     func test_201_unexpectedEOS() {
@@ -155,7 +161,12 @@ class ParserTests: XCTestCase {
         SWEXPThrow(Error.NonTerminatedQuotedString, try Parser.parse("(\"a\" \")"))
     }
     
-    func test_206_illegalHexCharacter() {
+    func test_206_missingAssignmentValue() {
+        SWEXPThrow(Error.MissingAssigmentValue, try Parser.parse("a="))
+        SWEXPThrow(Error.MissingAssigmentValue, try Parser.parse("a= "))
+    }
+    
+    func test_207_illegalHexCharacter() {
         SWEXPThrow(Error.IllegalHexCharacter(char: "x"), try Parser.parse("\"\\uxxxx\""))
         SWEXPThrow(Error.IllegalHexCharacter(char: " "), try Parser.parse("\"\\u    \""))
     }

--- a/SwiftExPTests/ParserTests.swift
+++ b/SwiftExPTests/ParserTests.swift
@@ -209,10 +209,17 @@ class ParserTests: XCTestCase {
     
     func test_301_swiftAstDump() {
         let bundle = NSBundle(forClass: ParserTests.self)
-        let path = bundle.pathForResource("test", ofType: "swift-ast")!
+        let pathToParse = bundle.pathForResource("test", ofType: "swift-ast")!
+        let pathToCompare = bundle.pathForResource("test.reserialized", ofType: "swift-ast")!
         SWXPAssertNoThrow {
-            let expr = try Parser.parse(contentsOfFile: path)
-            SWXPAssertEqual(String(expr), "")
+            let data = NSData(contentsOfFile: pathToCompare)!
+            let expectedString = NSString(data: data, encoding: NSUTF8StringEncoding)! as String
+            print(expectedString)
+
+            let expr = try Parser.parse(contentsOfFile: pathToParse)
+            let desc = expr!.prettyDescription()
+            print(desc)
+            SWXPAssertEqual(desc, expectedString)
         }
     }
     


### PR DESCRIPTION
An attempt at a reverse-engineered format definition, which is capable of handling the output format used by Swift compiler to serialize ASTs.
